### PR TITLE
fix Water Elemental size scaling; change announce default

### DIFF
--- a/conf/morphsummon.conf.dist
+++ b/conf/morphsummon.conf.dist
@@ -6,7 +6,7 @@
 
 # Announce the module when the player logs in?
 
-MorphSummon.Announce = 1
+MorphSummon.Announce = 0
 
 # Model IDs for the summoned permanent creatures
 

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -81,6 +81,16 @@ public:
             ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00MorphSummon |rmodule.");
         }
     }
+
+    void OnPetInitStatsForLevel(Pet* pet) override
+    {
+        if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+        {
+            // The size of the water elemental model is not automatically scaled, so needs to be done here
+            CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
+            pet->SetObjectScale(0.85f / displayInfo->scale);
+        }
+    }
 };
 
 class MorphSummon_CreatureScript : public CreatureScript
@@ -304,6 +314,13 @@ private:
                 {
                     pet->SetDisplayId(action - MORPH_PAGE_MAX);
                     pet->SetNativeDisplayId(action - MORPH_PAGE_MAX);
+
+                    if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+                    {
+                        // The size of the water elemental model is not automatically scaled, so needs to be done here
+                        CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
+                        pet->SetObjectScale(0.85f / displayInfo->scale);
+                    }
 
                     if (Aura* aura = pet->AddAura(SUBMERGE, pet))
                         aura->SetDuration(2000);


### PR DESCRIPTION
- fix the size scaling of the Water Elemental (the size of the Warlock's demons and the Death Knight's ghoul are scaled automatically, but not the Mage's Water Elemental)
- change default for the announce message to "off"