### PR TITLE
Improvements

### DIFF
--- a/conf/morphsummon.conf.dist
+++ b/conf/morphsummon.conf.dist
@@ -14,7 +14,7 @@ MorphSummon.Announce = 0
 
 # Allow new name for demons and ghouls
 
-MorphSummon.NewNameEnabled = 1
+MorphSummon.NewNameEnabled = 0
 
 # Model IDs for the summoned permanent creatures
 

--- a/conf/morphsummon.conf.dist
+++ b/conf/morphsummon.conf.dist
@@ -4,9 +4,17 @@
 #    mod-morphsummon configuration
 #####################################
 
+# Enable or disable the module
+
+MorphSummon.Enabled = 1
+
 # Announce the module when the player logs in?
 
 MorphSummon.Announce = 0
+
+# Allow new name for demons and ghouls
+
+MorphSummon.NewNameEnabled = 1
 
 # Model IDs for the summoned permanent creatures
 

--- a/data/sql/db-characters/base/morphsummon_ddl.sql
+++ b/data/sql/db-characters/base/morphsummon_ddl.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS `mod_morphsummon_felguard_weapon` (
-  `PlayerGUIDLow` int(10) unsigned NOT NULL,
-  `FelguardItemID` int(10) unsigned NOT NULL COMMENT 'Item ID for Felguard virtual item slot 0',
+  `PlayerGUIDLow` int unsigned NOT NULL,
+  `FelguardItemID` int unsigned NOT NULL COMMENT 'Item ID for Felguard virtual item slot 0',
   PRIMARY KEY (`PlayerGUIDLow`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='mod-morphsummon; used for custom Felguard weapons';

--- a/data/sql/db-world/base/morphsummon.sql
+++ b/data/sql/db-world/base/morphsummon.sql
@@ -12,7 +12,7 @@ SET @MENU_CHOICE     := @MENU_HELLO + 2;
 
 DELETE FROM `creature_template` WHERE `entry` = @ENTRY;
 INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
-(@ENTRY, 0, 0, 0, 0, 0, @NAME, @SUBNAME, NULL, 0, 80, 80, 2, 35, 0, 1, 1.14286, 1, 0, 0, 1, 2000, 2000, 8, 0, 2048, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 0, 0, 1, 0, 2, @SCRIPTNAME, 0);
+(@ENTRY, 0, 0, 0, 0, 0, @NAME, @SUBNAME, NULL, 0, 80, 80, 2, 35, 1, 1, 1.14286, 1, 0, 0, 1, 2000, 2000, 8, 0, 2048, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 0, 0, 1, 0, 2, @SCRIPTNAME, 0);
 
 DELETE FROM `creature_template_movement` WHERE `CreatureId` IN (@ENTRY);
 INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
@@ -28,12 +28,11 @@ DELETE FROM `gossip_menu_option` WHERE `MenuID` IN (@MENU_HELLO, @MENU_SORRY, @M
 INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
 (@MENU_HELLO, 0, 0, 'Choose polymorph', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_HELLO, 1, 0, 'Choose Felguard weapon', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
+(@MENU_HELLO, 2, 0, 'Generate new name', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_SORRY, 0, 0, 'Ah,  nevermind.', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 0, 0, 'Back..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 1, 4, 'Next..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 2, 4, 'Previous..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0);
 
 DELETE FROM `creature_template_model` where `CreatureID` = @ENTRY;
-INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES (@ENTRY, 0, @MODELID, 1, 1, 12340);
-
-UPDATE `creature_template` SET `npcflag`=`npcflag`|1 WHERE `entry`=@ENTRY;
+INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES (@ENTRY, 0, @MODELID, 1, 1, 0);

--- a/data/sql/db-world/base/morphsummon.sql
+++ b/data/sql/db-world/base/morphsummon.sql
@@ -29,7 +29,7 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 (@MENU_HELLO, 0, 0, 'Choose polymorph', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_HELLO, 1, 0, 'Choose Felguard weapon', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_HELLO, 2, 0, 'Generate new name', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
-(@MENU_SORRY, 0, 0, 'Ah,  nevermind.', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
+(@MENU_SORRY, 0, 0, 'Ah, nevermind.', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 0, 0, 'Back..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 1, 4, 'Next..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0),
 (@MENU_CHOICE, 2, 4, 'Previous..', 0, 0, 0, 0, 0, 0, 0, '', 0, 0);

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -338,14 +338,13 @@ private:
         bool showPolymorph = false;
         bool showNewName = morphSummonNewNameEnabled;
 
-        // Mage Pet (minion)
-        if (player->getClass() == CLASS_MAGE)
+        if (Pet* pet = player->GetPet())
         {
-            showNewName = false;
-
-            if (Minion* minion = player->GetFirstMinion())
+            if (player->getClass() == CLASS_MAGE)
             {
-                if (minion->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+                showNewName = false;
+
+                if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
                 {
                     if (!mage_water_elemental.empty())
                     {
@@ -354,10 +353,7 @@ private:
                     }
                 }
             }
-        }
-        else
-        {
-            if (Pet* pet = player->GetPet())
+            else
             {
                 switch (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL))
                 {
@@ -416,9 +412,9 @@ private:
                     break;
                 }
             }
-            else
-                showNewName = false;
         }
+        else
+            showNewName = false;
 
         if (showPolymorph || showNewName)
         {

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -195,9 +195,9 @@ public:
 class MorphSummonUnitScript : public UnitScript
 {
 public:
-    MorphSummonUnitScript() : UnitScript("MorphSummonUnitScript",
+    MorphSummonUnitScript() : UnitScript("MorphSummonUnitScript", true, {
         UNITHOOK_ON_AURA_REMOVE
-    ) {}
+    }) {}
 
     void OnAuraRemove(Unit* unit, AuraApplication* /*aurApp*/, AuraRemoveMode /*mode*/) override
     {

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -201,10 +201,10 @@ public:
 
     void OnAuraRemove(Unit* unit, AuraApplication* /*aurApp*/, AuraRemoveMode /*mode*/) override
     {
-        if (!morphSummonEnabled)
+        if (!morphSummonEnabled || unit->GetUInt32Value(UNIT_CREATED_BY_SPELL) != SUMMON_WATER_ELEMENTAL)
             return;
 
-        if (Pet* pet = unit->ToPet(); pet && pet->GetOwner() && pet->GetOwner()->IsPlayer() && pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+        if (Pet* pet = unit->ToPet(); pet && pet->GetOwner() && pet->GetOwner()->IsPlayer())
         {
             // The size of the water elemental model is not automatically scaled, so needs to be done here after auras are removed
             if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId()))
@@ -489,15 +489,27 @@ private:
     {
         if (Pet* pet = player->GetPet())
         {
-            std::string newName = sObjectMgr->GeneratePetName(pet->GetEntry());
-
-            if (!newName.empty())
+            switch (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL))
             {
-                pet->SetName(newName);
-                pet->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(GameTime::GetGameTime().count()));
+            case SUMMON_IMP:
+            case SUMMON_VOIDWALKER:
+            case SUMMON_SUCCUBUS:
+            case SUMMON_FELHUNTER:
+            case SUMMON_FELGUARD:
+            case RAISE_DEAD:
+                {
+                    std::string newName = sObjectMgr->GeneratePetName(pet->GetEntry());
 
-                if (player->GetGroup())
-                    player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_NAME);
+                    if (!newName.empty())
+                    {
+                        pet->SetName(newName);
+                        pet->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(GameTime::GetGameTime().count()));
+
+                        if (player->GetGroup())
+                            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_NAME);
+                    }
+                }
+                break;
             }
         }
     }

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -152,6 +152,10 @@ public:
                     {
                         pet->SetDisplayId(DISPLAY_ID_FELGUARD);
                         pet->SetNativeDisplayId(DISPLAY_ID_FELGUARD);
+                    }
+
+                    if (pet->GetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID) != ITEM_ID_FELGUARD_WEAPON)
+                    {
                         pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, ITEM_ID_FELGUARD_WEAPON);
                     }
                     break;

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -176,15 +176,12 @@ public:
                     break;
                 }
             }
-            else
+            else if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_FELGUARD)
             {
-                if (Pet* pet = guardian->ToPet(); pet && pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_FELGUARD)
+                if (QueryResult result = CharacterDatabase.Query("SELECT `FelguardItemID` FROM `mod_morphsummon_felguard_weapon` WHERE `PlayerGUIDLow`={}", player->GetGUID().GetCounter()))
                 {
-                    if (QueryResult result = CharacterDatabase.Query("SELECT `FelguardItemID` FROM `mod_morphsummon_felguard_weapon` WHERE `PlayerGUIDLow`={}", player->GetGUID().GetCounter()))
-                    {
-                        Field* fields = result->Fetch();
-                        pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, fields[0].Get<uint32>());
-                    }
+                    Field* fields = result->Fetch();
+                    pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, fields[0].Get<uint32>());
                 }
             }
         }

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -523,7 +523,7 @@ public:
     {
         morphSummonEnabled = sConfigMgr->GetOption<bool>("MorphSummon.Enabled", true);
         morphSummonAnnounce = sConfigMgr->GetOption<bool>("MorphSummon.Announce", false);
-        morphSummonNewNameEnabled = sConfigMgr->GetOption<bool>("MorphSummon.NewNameEnabled", true);
+        morphSummonNewNameEnabled = sConfigMgr->GetOption<bool>("MorphSummon.NewNameEnabled", false);
 
         if (defaultGhoulDisplayIds.empty())
         {

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -420,6 +420,7 @@ private:
         {
             if (showNewName)
                 AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_NEW_NAME, GOSSIP_SENDER_MAIN, MORPH_NEW_NAME);
+
             SendGossipMenuFor(player, MORPH_GOSSIP_TEXT_HELLO, creature->GetGUID());
         }
         else

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -4,6 +4,7 @@
 
 #include "Chat.h"
 #include "Config.h"
+#include "GameTime.h"
 #include "Pet.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
@@ -11,7 +12,6 @@
 #include "ScriptMgr.h"
 #include "SpellAuras.h"
 #include "Unit.h"
-#include "GameTime.h"
 
 std::map<std::string, uint32> warlock_imp;
 std::map<std::string, uint32> warlock_voidwalker;
@@ -155,9 +155,7 @@ public:
                     }
 
                     if (pet->GetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID) != ITEM_ID_FELGUARD_WEAPON)
-                    {
                         pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, ITEM_ID_FELGUARD_WEAPON);
-                    }
                     break;
                 case RAISE_DEAD:
                     if (!defaultGhoulDisplayIds.contains(pet->GetDisplayId()))

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -177,8 +177,8 @@ public:
             else if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
             {
                 // The size of the water elemental model is not automatically scaled, so needs to be done here
-                CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
-                pet->SetObjectScale(0.85f / displayInfo->scale);
+                if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId()))
+                    pet->SetObjectScale(0.85f / displayInfo->scale);
             }
             else if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_FELGUARD)
             {
@@ -201,11 +201,14 @@ public:
 
     void OnAuraRemove(Unit* unit, AuraApplication* /*aurApp*/, AuraRemoveMode /*mode*/) override
     {
+        if (!morphSummonEnabled)
+            return;
+
         if (Pet* pet = unit->ToPet(); pet && pet->GetOwner() && pet->GetOwner()->IsPlayer() && pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
         {
             // The size of the water elemental model is not automatically scaled, so needs to be done here after auras are removed
-            CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
-            pet->SetObjectScale(0.85f / displayInfo->scale);
+            if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId()))
+                pet->SetObjectScale(0.85f / displayInfo->scale);
         }
     }
 };

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -174,6 +174,12 @@ public:
                     break;
                 }
             }
+            else if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+            {
+                // The size of the water elemental model is not automatically scaled, so needs to be done here
+                CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
+                pet->SetObjectScale(0.85f / displayInfo->scale);
+            }
             else if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_FELGUARD)
             {
                 if (QueryResult result = CharacterDatabase.Query("SELECT `FelguardItemID` FROM `mod_morphsummon_felguard_weapon` WHERE `PlayerGUIDLow`={}", player->GetGUID().GetCounter()))
@@ -182,6 +188,24 @@ public:
                     pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, fields[0].Get<uint32>());
                 }
             }
+        }
+    }
+};
+
+class MorphSummonUnitScript : public UnitScript
+{
+public:
+    MorphSummonUnitScript() : UnitScript("MorphSummonUnitScript", {
+        UNITHOOK_ON_AURA_REMOVE
+    }) {}
+
+    void OnAuraRemove(Unit* unit, AuraApplication* /*aurApp*/, AuraRemoveMode /*mode*/) override
+    {
+        if (Pet* pet = unit->ToPet(); pet && pet->GetOwner() && pet->GetOwner()->IsPlayer() && pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == SUMMON_WATER_ELEMENTAL)
+        {
+            // The size of the water elemental model is not automatically scaled, so needs to be done here after auras are removed
+            CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(pet->GetNativeDisplayId());
+            pet->SetObjectScale(0.85f / displayInfo->scale);
         }
     }
 };
@@ -578,5 +602,6 @@ void AddMorphSummonScripts()
 {
     new MorphSummonWorldScript();
     new MorphSummonPlayerScript();
+    new MorphSummonUnitScript();
     new MorphSummonCreatureScript();
 }

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -411,8 +411,13 @@ private:
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_DEATH_KNIGHT_GHOUL);
                     }
                     break;
+                default:
+                    showNewName = false;
+                    break;
                 }
             }
+            else
+                showNewName = false;
         }
 
         if (showPolymorph || showNewName)
@@ -455,35 +460,26 @@ private:
 
     void Polymorph(Player *player, uint32 action, uint32 sender, uint32 startPage, uint32 maxPage, uint32 spell, std::map<std::string, uint32> &modelMap, bool polymorphPet)
     {
-        Creature* petOrMinion = nullptr;
-        Pet* pet = player->GetPet();
-        Minion* minion = player->GetFirstMinion();
-
-        if (pet != nullptr)
-            petOrMinion = pet;
-        else if (minion != nullptr)
-            petOrMinion = minion;
-
-        if (petOrMinion != nullptr)
+        if (Pet* pet = player->GetPet())
         {
             if (sender >= startPage && sender < maxPage)
             {
-                if (petOrMinion->GetUInt32Value(UNIT_CREATED_BY_SPELL) == spell)
+                if (pet->GetUInt32Value(UNIT_CREATED_BY_SPELL) == spell)
                 {
                     uint32 morphId = action - MORPH_PAGE_MAX;
 
                     if (polymorphPet)
                     {
-                        petOrMinion->SetDisplayId(morphId);
-                        petOrMinion->SetNativeDisplayId(morphId);
+                        pet->SetDisplayId(morphId);
+                        pet->SetNativeDisplayId(morphId);
 
-                        if (Aura *aura = petOrMinion->AddAura(SUBMERGE, pet))
+                        if (Aura *aura = pet->AddAura(SUBMERGE, pet))
                             aura->SetDuration(2000);
-                        petOrMinion->CastSpell(pet, SHADOW_SUMMON_VISUAL, true);
+                        pet->CastSpell(pet, SHADOW_SUMMON_VISUAL, true);
                     }
                     else
                     {
-                        petOrMinion->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, morphId);
+                        pet->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, morphId);
                         CharacterDatabase.Execute("REPLACE INTO `mod_morphsummon_felguard_weapon` (`PlayerGUIDLow`, `FelguardItemID`) VALUES ({}, {})", player->GetGUID().GetCounter(), morphId);
                     }
                 }

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -195,9 +195,9 @@ public:
 class MorphSummonUnitScript : public UnitScript
 {
 public:
-    MorphSummonUnitScript() : UnitScript("MorphSummonUnitScript", {
+    MorphSummonUnitScript() : UnitScript("MorphSummonUnitScript",
         UNITHOOK_ON_AURA_REMOVE
-    }) {}
+    ) {}
 
     void OnAuraRemove(Unit* unit, AuraApplication* /*aurApp*/, AuraRemoveMode /*mode*/) override
     {

--- a/src/morphsummon.cpp
+++ b/src/morphsummon.cpp
@@ -335,8 +335,8 @@ public:
 private:
     bool CreateMainMenu(Player* player, Creature* creature)
     {
-        bool sorry = true;
-        bool showNewName = true;
+        bool showPolymorph = false;
+        bool showNewName = morphSummonNewNameEnabled;
 
         // Mage Pet (minion)
         if (player->getClass() == CLASS_MAGE)
@@ -349,7 +349,7 @@ private:
                 {
                     if (!mage_water_elemental.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_MAGE_WATER_ELEMENTAL);
                     }
                 }
@@ -364,35 +364,35 @@ private:
                 case SUMMON_IMP:
                     if (!warlock_imp.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_WARLOCK_IMP);
                     }
                     break;
                 case SUMMON_VOIDWALKER:
                     if (!warlock_voidwalker.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_WARLOCK_VOIDWALKER);
                     }
                     break;
                 case SUMMON_SUCCUBUS:
                     if (!warlock_succubus.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_WARLOCK_SUCCUBUS);
                     }
                     break;
                 case SUMMON_FELHUNTER:
                     if (!warlock_felhunter.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_WARLOCK_FELHUNTER);
                     }
                     break;
                 case SUMMON_FELGUARD:
                     if (!warlock_felguard.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_WARLOCK_FELGUARD);
 
                         if (!felguard_weapon.empty())
@@ -400,14 +400,14 @@ private:
                     }
                     else if (!felguard_weapon.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_FELGUARD_WEAPON, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_FELGUARD_WEAPON);
                     }
                     break;
                 case RAISE_DEAD:
                     if (!death_knight_ghoul.empty())
                     {
-                        sorry = false;
+                        showPolymorph = true;
                         AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_POLYMORPH, GOSSIP_SENDER_MAIN, MORPH_PAGE_START_DEATH_KNIGHT_GHOUL);
                     }
                     break;
@@ -415,17 +415,16 @@ private:
             }
         }
 
-        if (sorry)
+        if (showPolymorph || showNewName)
         {
-            AddGossipItemFor(player, MORPH_GOSSIP_MENU_SORRY, MORPH_GOSSIP_OPTION_SORRY, GOSSIP_SENDER_MAIN, MORPH_CLOSE_MENU);
-            SendGossipMenuFor(player, MORPH_GOSSIP_TEXT_SORRY, creature->GetGUID());
+            if (showNewName)
+                AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_NEW_NAME, GOSSIP_SENDER_MAIN, MORPH_NEW_NAME);
+            SendGossipMenuFor(player, MORPH_GOSSIP_TEXT_HELLO, creature->GetGUID());
         }
         else
         {
-            if (showNewName && morphSummonNewNameEnabled)
-                AddGossipItemFor(player, MORPH_GOSSIP_MENU_HELLO, MORPH_GOSSIP_OPTION_NEW_NAME, GOSSIP_SENDER_MAIN, MORPH_NEW_NAME);
-
-            SendGossipMenuFor(player, MORPH_GOSSIP_TEXT_HELLO, creature->GetGUID());
+            AddGossipItemFor(player, MORPH_GOSSIP_MENU_SORRY, MORPH_GOSSIP_OPTION_SORRY, GOSSIP_SENDER_MAIN, MORPH_CLOSE_MENU);
+            SendGossipMenuFor(player, MORPH_GOSSIP_TEXT_SORRY, creature->GetGUID());
         }
 
         return true;
@@ -498,11 +497,11 @@ private:
     {
         if (Pet* pet = player->GetPet())
         {
-            std::string new_name = sObjectMgr->GeneratePetName(pet->GetEntry());
+            std::string newName = sObjectMgr->GeneratePetName(pet->GetEntry());
 
-            if (!new_name.empty())
+            if (!newName.empty())
             {
-                pet->SetName(new_name);
+                pet->SetName(newName);
                 pet->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(GameTime::GetGameTime().count()));
 
                 if (player->GetGroup())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
A few improvements to the module:

- Add a new config option `MorphSummon.Enabled` (Closes #9)
- Add a new gossip option to change the name of demons and ghouls; can be enabled using the config option `MorphSummon.NewNameEnabled` (I think this is the only part of my fork worth taking over, the other stuff is not needed)
- In `morphsummon_ddl.sql`: Use `int` instead of `int(10)`
- In `morphsummon.sql`:
  - The UPDATE statement is not needed, the correct `npcflag` is now in the INSERT statement above.
  - Set `VerifiedBuild` in `creature_template_model` to 0 as this is a custom creature which cannot be sniffed.
- The default of config option `MorphSummon.Announce` in the code is set to `false` to reflect the default in the config file.
- Use the correct spell ID for `SUMMON_WATER_ELEMENTAL`.
- Use `UNITHOOK_ON_AURA_REMOVE` to ensure that the water elemental always has the correct scale.
- A few bug fixes concerning the gossip options.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
none

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested applying the SQL scripts, compilation and in-game.

## How to Test the Changes:
Add creature with ID 601072 to the world and check the gossip options with different player classes. Warlocks and Death Knights have an additional option to generate a new name for their pet if config option `MorphSummon.NewNameEnabled` is set to 1.